### PR TITLE
Replace homebrew thread handling and health management

### DIFF
--- a/gitlab-ci-build-statuses.cabal
+++ b/gitlab-ci-build-statuses.cabal
@@ -88,6 +88,7 @@ library
       base >=4.7 && <5
     , aeson
     , aeson-casing
+    , async
     , barbies
     , bifunctors
     , blaze-html

--- a/src/Config/Backbone.hs
+++ b/src/Config/Backbone.hs
@@ -12,7 +12,6 @@ module Config.Backbone
   )
 where
 
-import Control.Concurrent (ThreadId)
 import Control.Lens
 import Core.BuildStatuses (BuildStatuses)
 import Core.Runners (RunnersJobs)
@@ -21,9 +20,9 @@ import Katip (LogContexts, LogEnv, Namespace)
 import Metrics.Metrics
 import Relude hiding (lookupEnv)
 
-initBackbone :: Metrics -> IORef BuildStatuses -> IORef RunnersJobs -> IORef [(ThreadId, Text)] -> IORef Bool -> LogConfig -> Backbone
-initBackbone metrics iorefBuilds iorefRunnersJobs iorefThreads health logConfig =
-  Backbone metrics iorefBuilds iorefRunnersJobs logConfig (GitCommit $ giTag gitCommit <> "/" <> giBranch gitCommit <> "@" <> giHash gitCommit) iorefThreads health
+initBackbone :: Metrics -> IORef BuildStatuses -> IORef RunnersJobs -> LogConfig -> Backbone
+initBackbone metrics iorefBuilds iorefRunnersJobs logConfig =
+  Backbone metrics iorefBuilds iorefRunnersJobs logConfig (GitCommit $ giTag gitCommit <> "/" <> giBranch gitCommit <> "@" <> giHash gitCommit)
   where
     gitCommit = $$tGitInfoCwd
 
@@ -32,9 +31,7 @@ data Backbone = Backbone
     statuses :: IORef BuildStatuses,
     runners :: IORef RunnersJobs,
     logConfig :: LogConfig,
-    gitCommit :: GitCommit,
-    threads :: IORef [(ThreadId, Text)],
-    health :: IORef Bool
+    gitCommit :: GitCommit
   }
 
 data LogConfig = LogConfig

--- a/src/Core/Effects.hs
+++ b/src/Core/Effects.hs
@@ -16,8 +16,6 @@ module Core.Effects
     logInfo,
     logWarn,
     logError,
-    Health (..),
-    isHealthy,
   )
 where
 
@@ -41,8 +39,3 @@ data Logger m a where
   AddNamespace :: Text -> m b -> Logger m b
 
 makeSem ''Logger
-
-data Health m a where
-  IsHealthy :: Health m Bool
-
-makeSem ''Health

--- a/src/Inbound/HTTP/Server.hs
+++ b/src/Inbound/HTTP/Server.hs
@@ -13,14 +13,13 @@ import Config.Backbone (Backbone (..), GitCommit)
 import Config.Config (Config (..), JobsView, UiUpdateIntervalSeconds)
 import Control.Exception (try)
 import Core.BuildStatuses (BuildStatuses, BuildStatusesApi)
-import Core.Effects (Health)
 import Core.Runners (RunnersJobs, RunnersJobsApi)
 import Core.Shared (DataUpdateIntervalSeconds)
 import Data.Time
 import qualified Inbound.HTTP.BuildStatuses.Html as BuildStatuses
 import qualified Inbound.HTTP.Runners.Html as Runners
 import Inbound.HTTP.Util
-import Metrics.Health (getCurrentHealthStatus, healthToIO)
+import Metrics.Health (getCurrentHealthStatus)
 import qualified Metrics.Health as Health
 import Network.Wai.Handler.Warp
 import Network.Wai.Middleware.Gzip (gzip)
@@ -45,7 +44,7 @@ type API' =
 api :: Proxy API
 api = Proxy
 
-server :: (Member BuildStatusesApi r, Member RunnersJobsApi r, Member (Time UTCTime d) r, Member Health r, Member (R.Reader DataUpdateIntervalSeconds) r, Member (R.Reader UiUpdateIntervalSeconds) r, Member (R.Reader GitCommit) r, Member (R.Reader JobsView) r) => ServerT API (Sem r)
+server :: (Member BuildStatusesApi r, Member RunnersJobsApi r, Member (Time UTCTime d) r, Member (R.Reader DataUpdateIntervalSeconds) r, Member (R.Reader UiUpdateIntervalSeconds) r, Member (R.Reader GitCommit) r, Member (R.Reader JobsView) r) => ServerT API (Sem r)
 server = s :<|> s
   where
     s =
@@ -61,13 +60,12 @@ norefreshFlag False = Refresh
 hoist :: Config -> Backbone -> ServerT API Handler
 hoist config backbone = hoistServer api (liftServer config backbone) server
 
-liftServer :: Config -> Backbone -> Sem '[BuildStatusesApi, RunnersJobsApi, Time UTCTime Day, Health, R.Reader DataUpdateIntervalSeconds, R.Reader UiUpdateIntervalSeconds, R.Reader GitCommit, R.Reader JobsView, R.Reader (IORef BuildStatuses), R.Reader (IORef RunnersJobs), Embed IO] a -> Handler a
+liftServer :: Config -> Backbone -> Sem '[BuildStatusesApi, RunnersJobsApi, Time UTCTime Day, R.Reader DataUpdateIntervalSeconds, R.Reader UiUpdateIntervalSeconds, R.Reader GitCommit, R.Reader JobsView, R.Reader (IORef BuildStatuses), R.Reader (IORef RunnersJobs), Embed IO] a -> Handler a
 liftServer Config {..} Backbone {..} sem =
   sem
     & buildStatusesApiToIO
     & runnersJobsApiToIO
     & interpretTimeGhc
-    & healthToIO health threads
     & R.runReader dataUpdateIntervalSecs
     & R.runReader uiUpdateIntervalSecs
     & R.runReader gitCommit
@@ -82,9 +80,9 @@ startServer config backbone =
   serve api (hoist config backbone)
     & prometheus def
     & gzip def
-    & runSettings (setPort 8282 . setGracefulShutdownTimeout (Just 2) . setShutdownHandlerDisablingHealth (health backbone) $ defaultSettings)
+    & runSettings (setPort 8282 . setGracefulShutdownTimeout (Just 2) . setShutdownHandler $ defaultSettings)
 
-setShutdownHandlerDisablingHealth :: IORef Bool -> Settings -> Settings
-setShutdownHandlerDisablingHealth health = setInstallShutdownHandler shutdownHandler
+setShutdownHandler :: Settings -> Settings
+setShutdownHandler = setInstallShutdownHandler shutdownHandler
   where
-    shutdownHandler closeSocket = void $ installHandler sigTERM (CatchOnce $ atomicWriteIORef health False >> closeSocket) Nothing
+    shutdownHandler closeSocket = void $ installHandler sigTERM (CatchOnce closeSocket) Nothing

--- a/src/Metrics/Health.hs
+++ b/src/Metrics/Health.hs
@@ -9,63 +9,28 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Metrics.Health (API, getCurrentHealthStatus, initThreads, initHealth, healthToIO, HealthStatus) where
+module Metrics.Health (API, getCurrentHealthStatus, HealthStatus) where
 
-import Control.Concurrent (ThreadId)
-import Control.Exception (throw)
-import Core.Effects (Health (IsHealthy), isHealthy)
-import Data.Aeson (ToJSON, encode)
-import GHC.Conc (ThreadStatus (ThreadDied, ThreadFinished), threadStatus)
-import GitHash (GitInfo, giBranch, giHash, giTag, tGitInfoCwd)
-import Network.HTTP.Types (hContentType)
+import Data.Aeson (ToJSON)
+import GitHash (giBranch, giHash, giTag, tGitInfoCwd)
 import Polysemy
 import Relude
-import Servant (Get, JSON, err503, errHeaders, (:>))
-import Servant.Server (errBody)
+import Servant (Get, JSON, (:>))
 
 type API = "health" :> Get '[JSON] HealthStatus
 
-getCurrentHealthStatus :: Member Health r => Sem r HealthStatus
-getCurrentHealthStatus = ifM isHealthy (pure healthy) (throw errorResponse)
-  where
-    errorResponse =
-      err503
-        { errBody = encode unhealthy,
-          errHeaders = [(hContentType, "application/json;charset=utf-8")]
-        }
-
-healthToIO :: Member (Embed IO) r => IORef Bool -> IORef [(ThreadId, Text)] -> InterpreterFor Health r
-healthToIO healthIORef threadsIORef = interpret $ \case
-  IsHealthy -> embed $ do
-    threads <- readIORef threadsIORef
-    health <- readIORef healthIORef
-    (&&) health <$> allM (isThreadHealthy . fst) threads
-
-isThreadHealthy :: ThreadId -> IO Bool
-isThreadHealthy = fmap (`notElem` [ThreadFinished, ThreadDied]) . threadStatus
-
-initThreads :: IO (IORef [(ThreadId, Text)])
-initThreads = newIORef []
-
-initHealth :: IO (IORef Bool)
-initHealth = newIORef True
+getCurrentHealthStatus :: Sem r HealthStatus
+getCurrentHealthStatus = pure $ HealthStatus HEALTHY buildInfo
 
 data HealthStatus = HealthStatus {status :: Status, build :: String}
   deriving stock (Generic)
   deriving anyclass (ToJSON)
 
-healthy :: HealthStatus
-healthy = HealthStatus HEALTHY buildInfo
-
-unhealthy :: HealthStatus
-unhealthy = HealthStatus UNHEALTHY buildInfo
-
 buildInfo :: String
 buildInfo = giTag gitCommit <> "/" <> giBranch gitCommit <> "@" <> giHash gitCommit
+  where
+    gitCommit = $$tGitInfoCwd
 
-gitCommit :: GitInfo
-gitCommit = $$tGitInfoCwd
-
-data Status = HEALTHY | UNHEALTHY
+data Status = HEALTHY
   deriving stock (Generic)
   deriving anyclass (ToJSON)


### PR DESCRIPTION
Previously, the different threads for updating statuses, updating
runners jobs, updating metrics, and running the server were started
using `forkIO`. This means that failures in the threads other than the
thread for the server (which was kind of the main thread) weren't
propagated and so it was possible that the app was running seemingly
fine, but the updating thread(s) died for some reason.
To mitigate that, a manual thread observation was implemented that used
the health API endpoint to signal when not all threads were running
anymore. This worked, but only when running in an environment like
Kubernetes in combination with a liveness probe that restarts the pod
when the liveness probe fails.
I don't like that the implementation was expecting certain things from
its environment to make sure that everything works.

The new approach makes use of the async package. All threads are wrapped
in a `Concrrently` newtype which we can compose using the Applicative
instance and then run it in one go. If one of the threads throws, the
failure will be propagated and the app will crash. This way, the app
will stop working whenever it can't do its job properly. Also, it's way
less code now and way less self made stuff in there.
There's one little downside: If one (or more than one, if at least one
thread remains running) thread just ends without an exception, we won't
notice. This is not too bad because I'm pretty sure that all threads
will run forever unless there's an exception (which also shouldn't
happen). It's even an advantage for when the runners jobs view is
disabled: We don't need any extra handling for that, we just `pure ()`
and we're good to go.