### PR TITLE
Expose the ports for Prometheus and Grafana

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -23,7 +23,8 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
-    network_mode: host
+    ports:
+      - '3000:3000'
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning/:/etc/grafana/provisioning/
@@ -35,7 +36,8 @@ services:
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus
-    network_mode: host
+    ports:
+      - '9090:9090'
     command:
       - --config.file=/etc/prometheus/prometheus.yml
     volumes:

--- a/docker-compose/grafana/provisioning/datasources/datasource.yml
+++ b/docker-compose/grafana/provisioning/datasources/datasource.yml
@@ -9,7 +9,7 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
-    url: http://127.0.0.1:9090
+    url: http://prometheus:9090
     password:
     user:
     database:

--- a/docker-compose/prometheus/prometheus.yml
+++ b/docker-compose/prometheus/prometheus.yml
@@ -7,24 +7,24 @@ scrape_configs:
     scrape_interval: 5s
     static_configs:
       - targets:
-          - 127.0.0.1:9090
+          - prometheus:9090
   - job_name: builds
     scrape_interval: 5s
     static_configs:
       - targets:
-          - 127.0.0.1:8282
+          - gitlab-ci-build-statuses:8282
   - job_name: nodeexporter
     scrape_interval: 5s
     static_configs:
       - targets:
-          - 127.0.0.1:9100
+          - node-exporter:9100
   - job_name: cadvisor
     scrape_interval: 5s
     static_configs:
       - targets:
-          - 127.0.0.1:8081
+          - cadvisor:8081
   - job_name: grafana
     scrape_interval: 5s
     static_configs:
       - targets:
-          - 127.0.0.1:3000
+          - grafana:3000


### PR DESCRIPTION
Using `newtork_mode: host` is not a good idea, as pointed out in #50