### PR TITLE
Gitlab/Instances: support projects without repositories

### DIFF
--- a/src/Ports/Outbound/Gitlab/Instances.hs
+++ b/src/Ports/Outbound/Gitlab/Instances.hs
@@ -48,7 +48,7 @@ instance FromJSON Project where
     projectId <- project .: "id"
     projectName <- project .: "name"
     projectWebUrl <- project .: "web_url"
-    projectDefaultBranch <- project .: "default_branch"
+    projectDefaultBranch <- project .:? "default_branch"
     projectNamespace <- project .: "namespace"
     pure Project {..}
 


### PR DESCRIPTION
These projects do not have a `default_branch` and GitLab does not return any key in the project API response for them.

Fixes: #223