### PR TITLE
Fetch the statuses for the latest pipelines of all active schedules

### DIFF
--- a/gitlab-ci-build-statuses.cabal
+++ b/gitlab-ci-build-statuses.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.38.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -53,6 +53,7 @@ library
       Ports.Outbound.Gitlab.Projects
       Ports.Outbound.Gitlab.RequestResponseUtils
       Ports.Outbound.Gitlab.Runners
+      Ports.Outbound.Gitlab.Schedules
       Ports.Outbound.Storage.BuildStatuses.InMemory
       Ports.Outbound.Storage.Runners.InMemory
       UseCases.BuildStatuses

--- a/src/App.hs
+++ b/src/App.hs
@@ -19,6 +19,7 @@ import Ports.Inbound.Jobs.Runners (updateRunnersJobsRegularly)
 import Ports.Outbound.Gitlab.Pipelines (pipelinesApiToIO)
 import Ports.Outbound.Gitlab.Projects (projectsApiToIO, projectsWithoutExcludesApiInTermsOfProjects)
 import Ports.Outbound.Gitlab.Runners (runnersApiToIO)
+import Ports.Outbound.Gitlab.Schedules (schedulesApiToIO)
 import Ports.Outbound.Storage.BuildStatuses.InMemory (buildStatusesApiToIO)
 import Ports.Outbound.Storage.Runners.InMemory (runnersJobsApiToIO)
 import Relude
@@ -44,6 +45,7 @@ startStatusUpdatingJob config backbone =
     . runConfig config
     . runBackbone backbone
     . buildStatusesApiToIO
+    . schedulesApiToIO
     . pipelinesApiToIO
     . metricsApiToIO
     . projectsApiToIO

--- a/src/Core/Shared.hs
+++ b/src/Core/Shared.hs
@@ -35,6 +35,6 @@ newtype Id a = Id Int deriving newtype (Eq, Hashable, Ord, Show)
 
 newtype Url a = Url URI deriving newtype (Eq, Show)
 
-newtype Ref = Ref Text deriving newtype (Eq, Ord, Show)
+newtype Ref = Ref {getRef :: Text} deriving newtype (Eq, Ord, Show)
 
 newtype Name a = Name Text deriving newtype (Eq, Show)

--- a/src/Ports/Inbound/HTTP/Server.hs
+++ b/src/Ports/Inbound/HTTP/Server.hs
@@ -48,7 +48,7 @@ server = s :<|> s
   where
     s =
       getCurrentHealthStatus
-        :<|> (\mvm b mfm mum -> BuildStatuses.template (fromMaybe Plain mvm) (fromMaybe ShowAll mfm) (fromMaybe Colored mum) (norefreshFlag b))
+        :<|> (\mvm b mfm msm mum -> BuildStatuses.template (fromMaybe Plain mvm) (fromMaybe ShowAll mfm) (fromMaybe ScheduledAndNotScheduled msm) (fromMaybe Colored mum) (norefreshFlag b))
         :<|> (Runners.template . norefreshFlag)
         :<|> serveDirectoryWebApp "/service/static"
 

--- a/src/Ports/Inbound/HTTP/Util.hs
+++ b/src/Ports/Inbound/HTTP/Util.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Ports.Inbound.HTTP.Util (AutoRefresh (..), ViewMode (..), FilterMode (..), UiMode (..), lastUpdatedToHtml) where
+module Ports.Inbound.HTTP.Util (AutoRefresh (..), ViewMode (..), FilterMode (..), UiMode (..), ShowMode (..), lastUpdatedToHtml) where
 
 import Core.Shared
 import Data.Time (UTCTime, diffUTCTime)
@@ -53,6 +53,19 @@ instance FromHttpApiData UiMode where
 
 instance ToHttpApiData UiMode where
   toQueryParam = uiModeToText
+
+data ShowMode = ScheduledAndNotScheduled | NoScheduled | OnlyScheduled deriving stock (Bounded, Eq, Enum)
+
+showModeToText :: ShowMode -> Text
+showModeToText ScheduledAndNotScheduled = "all"
+showModeToText NoScheduled = "no-scheduled"
+showModeToText OnlyScheduled = "only-scheduled"
+
+instance FromHttpApiData ShowMode where
+  parseQueryParam = maybeToRight "can't parse ShowMode param" . inverseMap showModeToText
+
+instance ToHttpApiData ShowMode where
+  toQueryParam = showModeToText
 
 lastUpdatedToHtml :: (Monad m) => DataUpdateIntervalSeconds -> UTCTime -> UTCTime -> HtmlT m ()
 lastUpdatedToHtml (DataUpdateIntervalSeconds updateInterval) now lastUpdate = div_ ([class_ classes] <> staleDataTitle) $ div_ $ do

--- a/src/Ports/Inbound/Jobs/BuildStatuses.hs
+++ b/src/Ports/Inbound/Jobs/BuildStatuses.hs
@@ -7,7 +7,7 @@ module Ports.Inbound.Jobs.BuildStatuses
 where
 
 import Config.Config (ExtraProjectsList)
-import Core.BuildStatuses (BuildStatusesApi, PipelinesApi, ProjectsApi, ProjectsWithoutExcludesApi)
+import Core.BuildStatuses (BuildStatusesApi, PipelinesApi, ProjectsApi, ProjectsWithoutExcludesApi, SchedulesApi)
 import Core.Effects (Logger, ParTraverse, addContext, addNamespace, logDebug)
 import Core.Shared
 import Metrics.Metrics
@@ -23,6 +23,7 @@ updateStatusesRegularly ::
     Member ProjectsWithoutExcludesApi r,
     Member DurationObservation r,
     Member PipelinesApi r,
+    Member SchedulesApi r,
     Member BuildStatusesApi r,
     Member Logger r,
     Member (Time t d) r,
@@ -41,6 +42,7 @@ updateWithDurationObservation ::
     Member ProjectsWithoutExcludesApi r,
     Member DurationObservation r,
     Member PipelinesApi r,
+    Member SchedulesApi r,
     Member BuildStatusesApi r,
     Member Logger r,
     Member ParTraverse r,

--- a/src/Ports/Outbound/Gitlab/Schedules.hs
+++ b/src/Ports/Outbound/Gitlab/Schedules.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Ports.Outbound.Gitlab.Schedules (schedulesApiToIO) where
+
+import Burrito
+import Config.Config (ApiToken (..), GitlabHost, UserAgent)
+import Core.BuildStatuses (SchedulesApi (..))
+import Core.Shared (Id (Id), Url (..))
+import Metrics.Metrics (OutgoingHttpRequestsHistogram)
+import Polysemy
+import Polysemy.Reader qualified as R
+import Ports.Outbound.Gitlab.Helpers
+import Ports.Outbound.Gitlab.Instances ()
+import Relude
+
+schedulesApiToIO :: (Member (Embed IO) r, Member (R.Reader (Url GitlabHost)) r, Member (R.Reader ApiToken) r, Member (R.Reader UserAgent) r, Member (R.Reader OutgoingHttpRequestsHistogram) r) => InterpreterFor SchedulesApi r
+schedulesApiToIO sem = do
+  baseUrl <- R.ask
+  apiToken <- R.ask
+  userAgent <- R.ask
+  histogram <- R.ask
+  schedulesApiToIO' baseUrl apiToken userAgent histogram sem
+
+schedulesApiToIO' :: (Member (Embed IO) r) => Url GitlabHost -> ApiToken -> UserAgent -> OutgoingHttpRequestsHistogram -> InterpreterFor SchedulesApi r
+schedulesApiToIO' baseUrl apiToken userAgent histogram =
+  interpret $ \case
+    GetActiveSchedulesForProject (Id project) -> do
+      let template = [uriTemplate|/api/v4/projects/{projectId}/pipeline_schedules?scope={scope}|]
+      embed $ fetchDataPaginated baseUrl apiToken userAgent template [("projectId", (stringValue . show) project), ("scope", stringValue "active")] histogram
+    GetSchedule (Id project) (Id schedule) -> do
+      let template = [uriTemplate|/api/v4/projects/{projectId}/pipeline_schedules/{scheduleId}|]
+      embed $ fetchData baseUrl apiToken userAgent template [("projectId", (stringValue . show) project), ("scheduleId", (stringValue . show) schedule)] histogram

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -20,6 +20,11 @@ pipelinesApiFromMaps pipelines detailedPipelines = interpret $ \case
   GetLatestPipelineForRef pId ref -> pure $ maybeToRight EmptyResult (M.lookup (pId, ref) pipelines)
   GetSinglePipeline pId pipelId -> pure $ maybeToRight EmptyResult (M.lookup (pId, pipelId) detailedPipelines)
 
+emptySchedulesApi :: InterpreterFor SchedulesApi r
+emptySchedulesApi = interpret $ \case
+  GetActiveSchedulesForProject _ -> pure $ Right []
+  GetSchedule _ _ -> pure $ Left EmptyResult
+
 parTraversePure :: InterpreterFor ParTraverse r
 parTraversePure =
   interpretH $ \case


### PR DESCRIPTION
When fetching the latest pipeline for each project, scheduled pipelines are excluded. In addition to that, all active schedules are fetched for each project, and the latest pipeline for each schedule will be included in the results.

In the UI, the tiles for each status now include the branch name (for non-scheduled pipelines) or the schedule description (for scheduled pipelines). The user can choose whether all, only scheduled, or only non-scheduled pipelines should be displayed.

Refers to #222